### PR TITLE
Fix word 4 not appearing in generate clue

### DIFF
--- a/lib/providers/encryption_key.dart
+++ b/lib/providers/encryption_key.dart
@@ -39,11 +39,10 @@ class EncryptionKey with ChangeNotifier {
     code.clear();
     filteredWords.clear();
 
-    code = new List<int>.generate(3, (int index) => index); // [0, 1, 4]
+    code = [0, 1, 2, 3];
     code.shuffle();
-    code.forEach((wordIndex) =>
-      filteredWords.add(words[wordIndex])
-    );
+    code.removeLast();
+    code.forEach((wordIndex) => filteredWords.add(words[wordIndex]));
     notifyListeners();
   }
 }


### PR DESCRIPTION
Closes #1 

Didn't see a point in generating such a small list when the `shuffle()` is going to randomise it anyway. 

Then `removeLast()` element in list after the randomisation so that we end up with a random set of numbers with having just 3.